### PR TITLE
removes duplicate duration display

### DIFF
--- a/lib/screens/series/series_screen.dart
+++ b/lib/screens/series/series_screen.dart
@@ -908,7 +908,6 @@ class _SeriesScreenState extends State<SeriesScreen> {
                           ),
                       ],
                     ),
-
                     if (episode.duration != null &&
                         episode.duration!.isNotEmpty) ...[
                       const SizedBox(height: 4),
@@ -920,20 +919,6 @@ class _SeriesScreenState extends State<SeriesScreen> {
                         ),
                       ),
                     ],
-                    // Süre bilgisi
-                    if (episode.duration != null &&
-                        episode.duration!.isNotEmpty) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        context.loc.duration(episode.duration!),
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Colors.grey.shade600,
-                        ),
-                      ),
-                    ],
-
-                    // Plot
                     if (episode.plot != null && episode.plot!.isNotEmpty) ...[
                       const SizedBox(height: 4),
                       Text(


### PR DESCRIPTION
removes a duplicate duration display in the series screen.

the duration was showing twice due to redundant conditional blocks.
