### PR TITLE
Fix: Refresh doesn't add some episodes for some series

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1235,7 +1235,7 @@ class AppDatabase extends _$AppDatabase {
   ) {
     return (select(episodes)..where(
           (tbl) =>
-              tbl.seriesId.equals(seriesId) & tbl.seriesId.equals(seriesId),
+              tbl.seriesId.equals(seriesId) & tbl.playlistId.equals(playlistId),
         ))
         .get();
   }
@@ -1249,7 +1249,7 @@ class AppDatabase extends _$AppDatabase {
           (tbl) =>
               tbl.seriesId.equals(seriesId) &
               tbl.season.equals(seasonNumber) &
-              tbl.seriesId.equals(seriesId),
+              tbl.playlistId.equals(playlistId),
         ))
         .get();
   }
@@ -1297,17 +1297,17 @@ class AppDatabase extends _$AppDatabase {
   Future<int> clearSeriesData(String seriesId, String playlistId) async {
     await (delete(episodes)..where(
           (tbl) =>
-              tbl.seriesId.equals(seriesId) & tbl.seriesId.equals(seriesId),
+              tbl.seriesId.equals(seriesId) & tbl.playlistId.equals(playlistId),
         ))
         .go();
     await (delete(seasons)..where(
           (tbl) =>
-              tbl.seriesId.equals(seriesId) & tbl.seriesId.equals(seriesId),
+              tbl.seriesId.equals(seriesId) & tbl.playlistId.equals(playlistId),
         ))
         .go();
     return await (delete(seriesInfos)..where(
           (tbl) =>
-              tbl.seriesId.equals(seriesId) & tbl.seriesId.equals(seriesId),
+              tbl.seriesId.equals(seriesId) & tbl.playlistId.equals(playlistId),
         ))
         .go();
   }


### PR DESCRIPTION
**Fixed issue #43, Please revise this as I don't know if there is an easy fix other than that**
 
Implements a smart caching mechanism for series details to prevent unnecessary network requests. This change introduces a `cacheBuster` parameter in the API request helper to force data refresh from the server only when needed.

Key changes include:
- Adding a `cacheBuster` flag to `_makeRequest` to append a timestamp and bypass caches.
- Implementing a staleness check for cached series data by comparing `lastModified` timestamps before fetching from the network.
- Improving the logic for determining an episode's season number by using the season key from the API response as a fallback.
- Adding error handling for database insertions of episodes.
- Fixing bugs in database queries related to `playlistId` filtering for series and episode data.