### PR TITLE
Temporary fix: video player pause when entering fullscreen in ios

### DIFF
--- a/lib/widgets/video_widget.dart
+++ b/lib/widgets/video_widget.dart
@@ -43,8 +43,9 @@ Widget getVideo(
         child: Scaffold(
           body: Video(
             controller: controller,
-            resumeUponEnteringForegroundMode: true,
-            pauseUponEnteringBackgroundMode: !PlayerState.backgroundPlay,
+            // plugin auto lifecycle handling turned off.
+            resumeUponEnteringForegroundMode: false,
+            pauseUponEnteringBackgroundMode: false,
             subtitleViewConfiguration: subtitleViewConfiguration,
           ),
         ),
@@ -74,8 +75,9 @@ Widget getVideo(
         child: Scaffold(
           body: Video(
             controller: controller,
-            resumeUponEnteringForegroundMode: true,
-            pauseUponEnteringBackgroundMode: !PlayerState.backgroundPlay,
+            // plugin auto lifecycle handling turned off.
+            resumeUponEnteringForegroundMode: false,
+            pauseUponEnteringBackgroundMode: false,
             subtitleViewConfiguration: subtitleViewConfiguration,
           ),
         ),
@@ -84,8 +86,9 @@ Widget getVideo(
       return Video(
         controller: controller,
         controls: NoVideoControls,
-        resumeUponEnteringForegroundMode: true,
-        pauseUponEnteringBackgroundMode: !PlayerState.backgroundPlay,
+        // plugin auto lifecycle handling turned off.
+        resumeUponEnteringForegroundMode: false,
+        pauseUponEnteringBackgroundMode: false,
         subtitleViewConfiguration: subtitleViewConfiguration,
       );
   }


### PR DESCRIPTION
Fix issue #24 : video player pause when entering full-screen in iOS

Improves app lifecycle handling for the player.

This change manually manages play/pause state when the app enters the background or foreground, replacing the video player plugin's automatic handling. It also ensures the `WidgetsBinding` observer is removed in `dispose` to prevent memory leaks.