### PR TITLE
Fix: Genre filtering logic 

### DIFF
--- a/lib/controllers/category_detail_controller.dart
+++ b/lib/controllers/category_detail_controller.dart
@@ -53,9 +53,10 @@ class CategoryDetailController extends ChangeNotifier {
     for (final item in items) {
       final rawGenre = _getItemGenre(item);
       if (rawGenre != null && rawGenre.isNotEmpty) {
+        // Split on common separators (comma, slash, backslash, pipe, ampersand, semicolon)
         final parts = rawGenre
-            .split(',')
-            .map((g) => g.trim().toLowerCase())
+            .split(RegExp(r'[,\/\\&\|;]+'))
+            .map((g) => g.trim())
             .where((g) => g.isNotEmpty)
             .toSet();
         genreSet.addAll(parts);
@@ -82,10 +83,18 @@ class CategoryDetailController extends ChangeNotifier {
   List<ContentItem> _applyGenreFilter(List<ContentItem> items) {
     if (_selectedGenre == null || _selectedGenre!.isEmpty) return items;
 
+    // We compare lowercased versions to be safe
     final genreLower = _selectedGenre!.toLowerCase();
     return items.where((item) {
-      final genres = _getItemGenre(item)?.toLowerCase() ?? '';
-      return genres.split(',').map((g) => g.trim()).contains(genreLower);
+      final rawGenre = _getItemGenre(item);
+      if (rawGenre == null) return false;
+
+      // Use the same splitter logic to check if the item contains the selected genre
+      final itemGenres = rawGenre
+          .split(RegExp(r'[,\/\\&\|;]+'))
+          .map((g) => g.trim().toLowerCase());
+
+      return itemGenres.contains(genreLower);
     }).toList();
   }
 


### PR DESCRIPTION
Fixed issue #42, This commit refactors the genre extraction and filtering logic. 

The genre splitting now handles multiple separators (e.g., `,`, `/`, `\`, `&`, `|`, `;`) instead of just commas. This ensures genres are parsed more reliably from various data sources.

Additionally, the genre matching is now case-insensitive, improving the accuracy of the genre filter.

<img width="634" height="670" alt="Screenshot 2025-11-29 142103 copy" src="https://github.com/user-attachments/assets/8d0fcffe-3d85-4c2b-9b4d-152086c29967" />
