### PR TITLE
Pin mediakit dependencies rather than building from main

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,9 +14,9 @@ dependencies:
     sdk: flutter
   intl: ^0.20.2
   get_it: ^7.2.0
-  media_kit: 1.2.6
-  media_kit_video: 2.0.1
-  media_kit_libs_video: 1.0.7
+  media_kit: ^1.2.6
+  media_kit_video: ^2.0.1
+  media_kit_libs_video: ^1.0.7
   provider: ^6.1.1
   drift: ^2.26.1
   sqlite3_flutter_libs: ^0.5.34

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,21 +14,9 @@ dependencies:
     sdk: flutter
   intl: ^0.20.2
   get_it: ^7.2.0
-  media_kit:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      path: media_kit
-      ref: main
-  media_kit_video:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      path: media_kit_video
-      ref: main
-  media_kit_libs_video:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      path: libs/universal/media_kit_libs_video
-      ref: main
+  media_kit: 1.2.6
+  media_kit_video: 2.0.1
+  media_kit_libs_video: 1.0.7
   provider: ^6.1.1
   drift: ^2.26.1
   sqlite3_flutter_libs: ^0.5.34
@@ -55,25 +43,6 @@ dependencies:
   url_launcher: ^6.3.2
   package_info_plus: ^8.0.0
   wakelock_plus: ^1.2.5
-
-dependency_overrides:
-  media_kit:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      path: media_kit
-      ref: main
-
-  media_kit_video:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      path: media_kit_video
-      ref: main
-
-  media_kit_libs_video:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      path: libs/universal/media_kit_libs_video
-      ref: main
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Building from main resulted in compile errors a couple months back, best practice is to build from a release